### PR TITLE
Adding new init(configuration:)

### DIFF
--- a/ios/Is It Viget/ViewController.swift
+++ b/ios/Is It Viget/ViewController.swift
@@ -92,7 +92,8 @@ class ViewController: UIViewController {
     // MARK: - Image classification
     lazy var classificationRequest: VNCoreMLRequest = {
         do {
-            let model = try VNCoreMLModel(for: VigetLogoClassifier().model)
+            let configuration = MLModelConfiguration()
+            let model = try VNCoreMLModel(for: VigetLogoClassifier(configuration: configuration).model)
             let request = VNCoreMLRequest(model: model, completionHandler: { [weak self] request, error in
                 self?.processClassifications(for: request, error: error)
             })


### PR DESCRIPTION
Hello! ,the old 'init()' is deprecated, so I simply added MLModelConfiguration() to fix the warning!